### PR TITLE
[OPS-2369] Streamline docker workflow for easier container re-use.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ taas.egg-info
 htmlcov
 build
 dist
+buildlog.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,34 @@ FROM unocha/alpine-base-s6-python2:latest
 
 MAINTAINER Paul Fenwick "paul@humanitarianresponse.info"
 
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ARG BUILD_DATE
+
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vendor="UN-OCHA" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.name="taas" \
+      org.label-schema.description="This container provides a python environments for Taxonomy as a Service." \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF
+
 # Git is everyone's favourite source control manager
 # Hub actually lets us make PRs to github
 # openssh is the transport needed to make PRs to github
-RUN apk add --update --no-cache git hub openssh
-RUN apk add --update --no-cache make
-RUN apk add --update --no-cache py-virtualenv
+RUN apk add --update --no-cache \
+      git hub openssh \
+      make \
+      py-virtualenv \
+      # These are needed so python can build its things.
+      gcc \
+      python-dev \
+      musl-dev \
+      linux-headers \
+      libffi-dev \
+      openssl-dev
 
-# These are needed so python can build its things
-RUN apk add --update --no-cache gcc
-RUN apk add --update --no-cache python-dev
-RUN apk add --update --no-cache musl-dev
-RUN apk add --update --no-cache linux-headers
-RUN apk add --update --no-cache libffi-dev
-RUN apk add --update --no-cache openssl-dev
+WORKDIR /tmp/taas
+CMD make update

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.schema-version="1.0" \
       org.label-schema.vendor="UN-OCHA" \
       org.label-schema.version=$VERSION \
       org.label-schema.name="taas" \
-      org.label-schema.description="This container provides a python environments for Taxonomy as a Service." \
+      org.label-schema.description="This container provides a python environment for Taxonomy as a Service." \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.vcs-ref=$VCS_REF
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 # We use --system-site-packages so we can potentially make Docker's life
 # easier by installing deps from apk.
 
+# We have some variables, used to tag the tag image. These can be overridden
+# by passing different versions on the CLI.
+ORGANISATION=unocha
+IMAGE=taas
+VERSION=1
+
+# And some helper binaries.
+AWK=awk
+DATE=date
+GIT=git
+SED=sed
+
 venv: requirements.txt
 	virtualenv --system-site-packages venv
 	venv/bin/pip install --upgrade pip
@@ -27,11 +39,21 @@ update:	venv FORCE
 freeze:
 	venv/bin/pip freeze | grep -v taas.git > requirements.txt
 
+# Tee the output to file, so we can parse it for tagging.
 docker:
-	docker build -f Dockerfile .
+	docker build \
+		--build-arg VCS_REF=`$(GIT) rev-parse --short HEAD` \
+		--build-arg VCS_URL=`$(GIT) config --get remote.origin.url | $(SED) 's#git@github.com:#https://github.com/#'` \
+		--build-arg BUILD_DATE=`$(DATE) -u +"%Y-%m-%dT%H:%M:%SZ"` \
+		--build-arg VERSION=$(VERSION) \
+		-f Dockerfile . | tee buildlog.txt
+
+tag:
+	$(eval IMAGE_HASH=$(shell tail -n 1 buildlog.txt | $(AWK) '{print $$NF}'))
+	docker tag $(IMAGE_HASH) $(ORGANISATION)/$(IMAGE):$(VERSION)
 
 clean:
-	rm -rf venv *.pyc .cache tests/__pycache__ .coverage taas.egg-info htmlcov
+	rm -rf venv *.pyc .cache tests/__pycache__ .coverage taas.egg-info htmlcov buidlog.txt
 
 # Magical line that allows us to force execution of a target
 FORCE:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you really want to...
 $ git checkout UN-OCHA/taas
 $ git checkout UN-OCHA/taas-data
 $ cd taas
-$ docker build .
+$ make docker tag VERSION=1
 $ docker run                                                \
     --rm --name tmp-tass                                    \
     -v ~/.config/hub:/root/.config/hub                      \
@@ -55,7 +55,7 @@ $ docker run                                                \
     -e 'GIT_COMMITTER_EMAIL=paul@humanitarianresponse.info' \
     -e 'GIT_AUTHOR_NAME=BeepBoop'                           \
     -e 'GIT_AUTHOR_EMAIL=paul@humanitarianresponse.info'    \
-    YourDockerBuildHere make update
+    unochaorg/taas:1 make update
 ```
 
 Things to note:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ docker run                                                \
     -e 'GIT_COMMITTER_EMAIL=paul@humanitarianresponse.info' \
     -e 'GIT_AUTHOR_NAME=BeepBoop'                           \
     -e 'GIT_AUTHOR_EMAIL=paul@humanitarianresponse.info'    \
-    unochaorg/taas:1 make update
+    unocha/taas:1 make update
 ```
 
 Things to note:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/UN-OCHA/taas/badge.svg?branch=master)](https://coveralls.io/github/UN-OCHA/taas)
 [![Code Climate](https://lima.codeclimate.com/github/UN-OCHA/taas/badges/gpa.svg)](https://lima.codeclimate.com/github/UN-OCHA/taas)
 [![Issue Count](https://lima.codeclimate.com/github/UN-OCHA/taas/badges/issue_count.svg)](https://lima.codeclimate.com/github/UN-OCHA/taas)
+[![Image Version](https://images.microbadger.com/badges/version/unocha/taas.svg)](https://microbadger.com/images/unocha/taas)
+[![Image Layers](https://images.microbadger.com/badges/image/unocha/taas.svg)](https://microbadger.com/images/unocha/taas)
 
 This code that powers the UN Office for the Coordination of Humanitarian Affairs (UN-OCHA)
 Taxnonomy as a Service APIs.


### PR DESCRIPTION
* Add Makefile steps to build and tag a re-usable docker image
* Add label metadata to the Dockerfile.
* Concatenate Dockerfile RUN steps for fewer image layers. Not less image layers. This is important.
* Set a default workdir and entrypoint in Dockerfile.
* Update the README appropriately.
* 🍨