### PR TITLE
[TAAS-20] Add support for organisations

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -45,7 +45,7 @@ sources:
                     optional: True
 
     organizations:
-        v1:
+        beta-v1:
             key: 1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ
             gid: 518938746
             mapping:

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -43,3 +43,27 @@ sources:
                 label.es:
                     field: Spanish Term
                     optional: True
+
+    organizations:
+        v1:
+            key: 1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ
+            gid: 518938746
+            mapping:
+                id: HR info ID
+                label: Preferred Term
+                acronym:
+                    type: map
+                    field: ACRONYM
+                    optional: True
+                homepage:
+                    type: map
+                    field: homepage
+                    optional: True
+                type:
+                    type: link
+                    field: OrgTypeID - OrgTypePreferredTerm
+                    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organization_types/
+                fts_id:
+                    type: map
+                    field: FinancialTrackingService ID
+                    optional: True


### PR DESCRIPTION
This adds a support for organisations to our repertoire of JSON documents. Here's a sample output:

```
{
    "acronym": "CI", 
    "fts_id": "7055", 
    "homepage": "http://www.caritas.org/", 
    "id": "452", 
    "label": "Caritas Internationalis", 
    "type": "https://www.humanitarianresponse.info/en/api/v1.0/organization_types/437"
}
```

Note that:

- I'm linking our orgtype back to HumanitarianResponse, because we don't have a TaaS organisation_type endpoint published yet, and our own code doesn't support individual records yet.
- I've called the endpoint `organizations`, as that matches our [existing API](https://www.humanitarianresponse.info/api/v1.0/organizations). I'm happy to flip to Commonwealth English if desired. :)
- I've used the same field names as exist in the current API.