### PR TITLE
Add link and multimap support

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -37,11 +37,9 @@ sources:
                 label.en: Preferred Term
 
                 label.fr:
-                    type: map
                     field: French Term
                     optional: True
 
                 label.es:
-                    type: map
                     field: Spanish Term
                     optional: True

--- a/taas/mapping.py
+++ b/taas/mapping.py
@@ -141,7 +141,7 @@ def make_map(mapping):
             fieldmap[field] = Map({"field": mapping[field]})
         else:
             # Complex case!
-            classname = map_type[config["type"]]
+            classname = map_type[config.get("type", "map")]
             fieldmap[field] = classname(mapping[field])
 
     return fieldmap

--- a/taas/mapping.py
+++ b/taas/mapping.py
@@ -61,6 +61,15 @@ class Concat(Map):
     def emit(self, row):
         value = super().emit(row)
 
+        return self._emit(value)
+
+    def _emit(self, value):
+        """
+            Internal function that generates our concatenated string.
+            Separated out for the benefit of child classes that may
+            wish to pre-adjust our values.
+        """
+
         # This implies our field was optional. If it wasn't,
         # our parent class would have raised an exception.
         if value is None:
@@ -69,12 +78,34 @@ class Concat(Map):
         return self.pre + value + self.post
 
 
+class Link(Concat):
+    """
+    A smart concat class that can handle our link format
+    in the form "ID - Human String"
+    """
+
+    def __init__(self, config):
+        # Even though we're not doing anything here, we still have
+        # to delegate our __init__ otherwise we end up recursing.
+        super().__init__(config)
+
+    def emit(self, row):
+        # We'll start by getting the raw data.
+        raw = Map.emit(self, row)
+
+        # Then we drop everything before a literal ' - '
+        ident = raw.split(' - ', 1)[0]
+
+        # And pass up to our parent class to turn into a link
+        return super()._emit(ident)
+
 # Helper/builder functions
 
 map_type = {
     "literal": Literal,
     "map": Map,
-    "concat": Concat
+    "concat": Concat,
+    "link": Link
 }
 
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -107,6 +107,12 @@ class TestMapping(unittest.TestCase):
                 "type": "map",
                 "field": "bar"
             },
+
+            # Bazza is the same, type: map is assumed.
+            "bazza": {
+                "field": "bar"
+            },
+
             "lit": {
                 "type": "literal",
                 "value": "MyLiteralString"
@@ -122,5 +128,6 @@ class TestMapping(unittest.TestCase):
 
         assert(isinstance(made_map["foo"], Map))
         assert(isinstance(made_map["baz"], Map))
+        assert(isinstance(made_map["bazza"], Map))
         assert(isinstance(made_map["lit"], Literal))
         assert(isinstance(made_map["con"], Concat))

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -45,6 +45,16 @@ class TestMapping(unittest.TestCase):
         with self.assertRaises(ValueError):
             strictmap.emit({"foo": ""})
 
+    def test_map_extended(self):
+        """Tests the extended map sequence, which takes multiple fields"""
+        mymap = Map({"field": ["foo", "bar"]})
+
+        self.assertEqual(mymap.emit({"foo": "Foo", "bar": "Bar"}), "Foo")
+        self.assertEqual(mymap.emit({"foo": "", "bar": "Bar"}), "Bar")
+
+        with self.assertRaises(ValueError):
+            mymap.emit({"foo": "", "bar": ""})
+
     def test_concat(self):
         concat = Concat({
             "field": "id",

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,4 +1,4 @@
-from taas.mapping import Literal, Map, Concat, make_map
+from taas.mapping import Literal, Map, Concat, Link, make_map
 import unittest
 
 
@@ -7,7 +7,8 @@ class TestMapping(unittest.TestCase):
     row = {
         "id": "3",
         "foo": "bar",
-        "baz": "bazza"
+        "baz": "bazza",
+        "link": "42 - Some other endpoint"
     }
 
     def test_literal(self):
@@ -54,6 +55,29 @@ class TestMapping(unittest.TestCase):
         self.assertEqual(
             concat.emit(self.row),
             "https://example.com/3/self"
+        )
+
+    def test_concat_optional(self):
+        concat = Concat({
+            "field": "id",
+            "prefix": "https://example.com/",
+            "optional": True
+        })
+
+        self.assertEqual(
+            concat.emit({"id": ""}),
+            None
+        )
+
+    def test_link(self):
+        link = Link({
+            "field": "link",
+            "prefix": "https://example.com/"
+        })
+
+        self.assertEqual(
+            link.emit(self.row),
+            "https://example.com/42"
         )
 
     def test_make_map(self):


### PR DESCRIPTION
## Links

A number of our sheets have fields in the form "numeric ident - human string". We introduce a link type that explicitly supports these. These are a child class of the `concat` class, so we can provide a prefix using the same syntax.

To take an example from PR#12 (which uses this):

```
orgtype:
    type: link
    field: OrgTypeID - OrgTypePreferredTerm
    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organization_types/
```

This takes a link such as "437 - International NGO" and returns "https://www.humanitarianresponse.info/en/api/v1.0/organization_types/437".

Links work by looking for the literal divider ` - `.

These changes are required to support [TAAS-20] (organisations).

## Multi-maps

Some of our sheets, such as countries, have a preferred term along with a number of website specific terms. These changes allow us to specify a list of fields which are to be checked in order of preference for populating a field.

The big advantage of this is that it allows us to ensure that a field is always populated. For example, m49 terms *mostly* overlap with our preferred terms, but have some exceptions. We can write that succiently in our config now as:

```
label.m49:
    field:
        - m49 Alt Term
        - Preferred Term
```

This will use the m49 term if it exists, and fall back to the preferred term otherwise.

These changes will be required to support [TAAS-18] (countries).

## Note for reviewers

It may be easier to examine each commit in turn rather than all at once, as they each perform a single change, and come with associated tests.