### PR TITLE
[TAAS-18] Add countries support

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -45,7 +45,7 @@ sources:
                     optional: True
 
     countries:
-        v1:
+        beta-v1:
             key: 1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY
             gid: 1528390745
             mapping:

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -62,6 +62,15 @@ sources:
                     field: ISO 3166-2:2013 Alpha 2-Codes
                     optional: True
 
+                # The old HRinfo ID, in case people want to match.
+                hrinfo_id:
+                    field: HRinfo ID
+                    optional: True
+
+                admin_level:
+                    field: Admin Level
+                    optional: True
+
                 # We have historical ISO-3166 data, but it does not appear in
                 # the original API, has only a single location in our
                 # spreadsheet which has a code. Since we're going for a minimum
@@ -79,7 +88,7 @@ sources:
                 # it very clear that these are all variations of the same name.
                 label.default: Preferred Term
 
-                label.hrinfo:
+                label.humanitarianresponse:
                     field:
                         - HRinfo Alt Term
                         - Preferred Term
@@ -101,6 +110,12 @@ sources:
                         - m49 Alt Term
                         - Preferred Term
 
-                # Our locations intentionally no longer include Lat/Long.
-                # Because this is allegedly a list of countries, we do not
-                # include admin level either.
+                # Lat/Long are a map, these keep backwards compatibility
+                # with our old API.
+                geolocation.lat:
+                    field: Latitude
+                    optional: True
+
+                geolocation.lon:
+                    field: Longitude
+                    optional: True

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -43,3 +43,64 @@ sources:
                 label.es:
                     field: Spanish Term
                     optional: True
+
+    countries:
+        v1:
+            key: 1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY
+            gid: 1528390745
+            mapping:
+                # id and iso3 are in the original "locations" API.
+                # https://www.humanitarianresponse.info/api/v1.0/locations
+                id: ID
+
+                iso3:
+                    field: ISO 3166-3:2013 Alpha 3-Codes
+                    optional: True
+
+                # The orignal API codes the ISO-2 code as 'pcode'. We don't.
+                iso2:
+                    field: ISO 3166-2:2013 Alpha 2-Codes
+                    optional: True
+
+                # We have historical ISO-3166 data, but it does not appear in
+                # the original API, has only a single location in our
+                # spreadsheet which has a code. Since we're going for a minimum
+                # viable product, and ISO standards are complex, we're not
+                # publishing it here.
+
+                # m49 code is new with our API.
+                m49:
+                    field: m49 numerical code
+                    optional: True
+
+                # Label is in the original API, but we now have a bunch of
+                # alternatives.  We supply a map because that shows semantic
+                # association. This is *not* backwards compatible, but makes
+                # it very clear that these are all variations of the same name.
+                label.default: Preferred Term
+
+                label.hrinfo:
+                    field:
+                        - HRinfo Alt Term
+                        - Preferred Term
+
+                # Reliefweb has *two* different names for countries, depending
+                # on where they get used.
+                label.reliefweb-name:
+                    field:
+                        - RW Name Alt Term
+                        - Preferred Term
+
+                label.reliefweb-web:
+                    field:
+                        - RW Website Alt Term
+                        - Preferred Term
+
+                label.m49:
+                    field:
+                        - m49 Alt Term
+                        - Preferred Term
+
+                # Our locations intentionally no longer include Lat/Long.
+                # Because this is allegedly a list of countries, we do not
+                # include admin level either.


### PR DESCRIPTION
This supports a `countries` endpoint. Sample output:

```
{
    "id": "2", 
    "iso2": "AX", 
    "iso3": "ALA", 
    "label": {
        "default": "\u00c5land Islands", 
        "hrinfo": "\u00c5land Islands", 
        "m49": "\u00c5land Islands", 
        "reliefweb-name": "\u00c5land Islands", 
        "reliefweb-web": "Aland Islands (Finland)"
    }, 
    "m49": "248"
}
```


This includes code from PR #13.

Things to note:

- b3cdfe9 is the config change. Everything else is from PR #13 which we need to run. Please just comment on b3cdfe9 here.
- I've taken exception to the ISO-2 code being called `pcode`. It's now `iso2`.
- The `label` field is now a map. `label.default` is the preferred term, but one can now select which labelling scheme to use.
- This is allegedly a countries sheet, but contains a number of territories and regions, like American Samoa and the US Virgin Islands. I'd like confirmation that the [data we're using](https://docs.google.com/spreadsheets/d/1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY/edit#gid=1528390745) is indeed what we want to publish.
- We're no longer publishing lat/long, as this is controversial.
- I'm not publishing the old HRinfo ID, but can if desired.
- I'm not publishing the Admin Level, since it should always be zero for countries. In addition, territories and other regions in this sheet are mmissing an admin level, and it feels like this *should not* be an optional field.

## Feedback from review:

Required:
- [x] Change `label.hrinfo` to `label.humanitarianresponse`.
- [x] Add in lat/long.

Suggested:
- [x] Publish old HRinfo ID
- [x] Publish admin level

## ToDo

- [x] @pjf to review [JIRA discussions](https://humanitarian.atlassian.net/browse/TAAS-18)