### PR TITLE
[TAAS-21] Add support for global_clusters

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -47,7 +47,7 @@ sources:
                     optional: True
 
     global_clusters:
-        v1:
+        beta-v1:
             key: 1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4
             gid: 0
             mapping:

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -53,6 +53,6 @@ sources:
             mapping:
                 id: HRinfo ID
                 label: Preferred Term
-                acryonym: ACRONYM
+                acronym: ACRONYM
                 group_type: Group Type
                 homepage: Homepage

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -54,5 +54,5 @@ sources:
                 id: HRinfo ID
                 label: Preferred Term
                 acryonym: ACRONYM
-                group: Group
+                group_type: Group Type
                 homepage: Homepage

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -45,3 +45,14 @@ sources:
                     type: map
                     field: Spanish Term
                     optional: True
+
+    global_clusters:
+        v1:
+            key: 1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4
+            gid: 0
+            mapping:
+                id: HRinfo ID
+                label: Preferred Term
+                acryonym: ACRONYM
+                group: Group
+                homepage: Homepage


### PR DESCRIPTION
This adds support for global clusters, which are blessedly simple. The sheet they load from is [here](https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0).

Sample output:

```
{
    "acryonym": "SHL", 
    "group": "Global Cluster", 
    "homepage": "https://www.sheltercluster.org/", 
    "id": "4", 
    "label": "Emergency Shelter and NFI"
}
```

Things to note:

- We have no global clusters API endpoint at the moment. The closest is `bundles`, but it serves a very different and more complex set of data.
- The `group` is always "Global Cluster" or "Area of Responsibility". These feel like they should be machine-friendly terms. Should they have links to anywhere?
- I'm not exporting "date created" or similar columns, since they're just asking to be incorrectly updated.
- We're using the HRinfo ID for now, but we may wish to create our own ID column and use that.

ToDo:

- [x] @pjf to review [jira conversation](https://humanitarian.atlassian.net/browse/TAAS-21).