### PR TITLE
[TAAS-37] Update endpoints from v1 to beta-v1

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -6,7 +6,7 @@
 sources:
     # This maps directly to the API URL
     functional_roles:
-        v1:
+        beta-v1:
             # Extracted from the spreadsheet URL
             key: 1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk
 


### PR DESCRIPTION
As per TAAS-37 we want to make it clear to consumers that our output is still under development. This PR changes the output of `functional_roles` to export to `beta-v1/functional_roles.json` rather than just `v1/functional_roles.json`.

Our workflow doesn't yet support removal of files, so if we accept this we'll want to remove the old `v1` directory in the `taas-data` repo manually.

PR #12, #14, and #15 have also been amended to use the new beta naming scheme.