### PR TITLE
[TAAS-18] A minimum viable countries API.

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -54,3 +54,36 @@ sources:
                 acronym: ACRONYM
                 group_type: Group Type
                 homepage: Homepage
+
+    countries:
+        beta-v1:
+            key: 1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY
+            gid: 1528390745
+            mapping:
+                id: ID
+
+                iso3:
+                    field: ISO 3166-3:2013 Alpha 3-Codes
+                    optional: True
+
+                iso2:
+                    field: ISO 3166-2:2013 Alpha 2-Codes
+                    optional: True
+
+                admin_level:
+                    field: Admin Level
+                    optional: True
+
+                # Label is now part of a JSON map, as we expect to add
+                # additional label terms in the future for
+                # interoperability with various services.
+
+                label.default: Preferred Term
+
+                geolocation.lat:
+                    field: Latitude
+                    optional: True
+
+                geolocation.lon:
+                    field: Longitude
+                    optional: True


### PR DESCRIPTION
In line with the discussion [on JIRA](https://humanitarian.atlassian.net/browse/TAAS-18?focusedCommentId=63325&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-63325),
this *only* exports fields that are in the current API.

Our records look like this:

```
    {
        "admin_level": "0", 
        "geolocation": {
            "lat": "33.83147477", 
            "lon": "66.02621828"
        }, 
        "id": "1", 
        "iso2": "AF", 
        "iso3": "AFG", 
        "label": {
            "default": "Afghanistan"
        }
    }
```

This supersedes PR #14.