### PR TITLE
[TAAS-20] config.yml: Add `organization_types`

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -139,3 +139,25 @@ sources:
                 geolocation.lon:
                     field: Longitude
                     optional: True
+
+    organization_types:
+        beta-v1:
+            key: 12nKxos71U6lkttpyYTfwI2bDq9yeN1J7jplHocN96_0
+            gid: 0
+            mapping:
+                id: HR.info ID
+                scope: Scope
+
+                label.default: Preferred Term
+                label.reliefweb:
+                    field: RW Alt Term
+                    optional: True
+
+                reliefweb_id:
+                    field: RW API ID
+                    optional: True
+
+                x-reliefweb-term-is:
+                    field: "Match type - RW term is:"
+                    optional: True
+


### PR DESCRIPTION
This adds `organization_types` to our exports.

Sample Records
--------------

```
{
    "id": "431", 
    "label": {
        "default": "Academic / Research", 
        "reliefweb": "Academic and Research Institution"
    }, 
    "reliefweb_id": "270", 
    "scope": "Includes universities, colleges, think tanks, private organizations focusing on research and analysis", 
    "x-reliefweb-term-is": "Exact Match"
},
{
    "id": "433", 
    "label": {
        "default": "Donor", 
        "reliefweb": null
    }, 
    "reliefweb_id": null, 
    "scope": "Organizations responsible for donating money, goods or other in-kind contributions. ", 
    "x-reliefweb-term-is": null
}, 

```

Spelling
--------

We use the US spelling of `organization`, as that's what the current HR.info API uses.

Labels
------

Our labels are *not* compatible with the existing API, which has a single top-level key named `label`. Instead, we're consistent with the other data we export, where we present `label` as a map with a `default` key where multiple options exist in the same langauge, or an `i-default` key where multiple languages exist.

In the case where there is no RW term, the ReliefWeb fields are null. They do not have defaults.

`x-reliefweb-term-is`
---------------------
Trying to present the relationship of the RW term to the default term in a machine-friendly way is tricky. We can break all the reliefweb information out into a separate structure:

```
{
    "id": "431", 
    "label": "Academic / Research", 
    "scope": "Includes universities, colleges, think tanks, private organizations focusing on research and analysis", 
    "reliefweb": {
        "label": "Academic and Research Institution"
        "id": "270", 
        "label-is": "Exact Match"
    }
}
```

On the surface this looks *better*, because we're backwards compatible with the existing HR.info API, however it means we're no longer consistent between our *own* APIs in how we handle label alternatives. If we go down this route, I'd like to update our other exports to match.

Alternatively, we could try to add additional decorations to the `label` map, but every example I go to write looks un-necessarily complex whenever I go down this route.

Rather than lock us into a format which is either inconsistent or complex, I've instead presented this data using the `x-reliefweb-term-is` field, which means we can encourage discussions with our data consumers as to how they may best find this of use.

## Dates

We're not exporting dates (added/changed), because none of our other exports do this.