### PR TITLE
[TAAS-32] Support for `url` over key/gid

### DIFF
--- a/taas/__init__.py
+++ b/taas/__init__.py
@@ -292,8 +292,16 @@ def process_source(source_name, source):
     for version in source:
         options = source[version]
 
+        # Older configs had a key and gid pair.
+        key = options.get('key', None)
+        gid = options.get('gid', None)
+
+        # Newer configs have a url, which we split into key/gid.
+        if 'url' in options:
+            (key, gid) = split_url(options['url'])
+
         google_sheet_to_json(
-            source_name, version, options['key'], options['gid'], options['mapping']
+            source_name, version, key, gid, options['mapping']
         )
 
 

--- a/taas/config.yml
+++ b/taas/config.yml
@@ -7,12 +7,7 @@ sources:
     # This maps directly to the API URL
     functional_roles:
         beta-v2:
-            # Extracted from the spreadsheet URL
-            key: 1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk
-
-            # Sheet number. Obtained from the google spreadsheet URL
-            # at the end (`gid=XX`).
-            gid: 0
+            url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
 
             # Mapping of column names -> API fields
             # Columns that aren't mentioned get ignored.
@@ -46,8 +41,7 @@ sources:
 
     global_coordination_groups:
         beta-v1:
-            key: 1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4
-            gid: 0
+            url: https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0
             mapping:
                 id: HRinfo ID
                 label: Preferred Term
@@ -57,8 +51,7 @@ sources:
 
     countries:
         beta-v1:
-            key: 1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY
-            gid: 1528390745
+            url: https://docs.google.com/spreadsheets/d/1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY/edit#gid=1528390745
             mapping:
                 id: ID
 

--- a/tests/test_taas.py
+++ b/tests/test_taas.py
@@ -72,3 +72,13 @@ class TestTaas(unittest.TestCase):
 
         self.assertEqual(taas.sheets_root(), os.path.join(data_root, "sheets"))
         self.assertEqual(taas.json_root(), os.path.join(data_root, "json"))
+
+    def test_split_url(self):
+
+        # Our test data is our countries sheet.
+        result = taas.split_url(
+            "https://docs.google.com/spreadsheets/d/1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY/edit#gid=1528390745"
+        )
+
+        self.assertEqual(result.key, "1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY")
+        self.assertEqual(result.gid, "1528390745")

--- a/tests/test_taas.py
+++ b/tests/test_taas.py
@@ -82,3 +82,13 @@ class TestTaas(unittest.TestCase):
 
         self.assertEqual(result.key, "1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY")
         self.assertEqual(result.gid, "1528390745")
+
+    def test_key_gid_clash(self):
+
+        # Supplying key/gid with URL should give us an error containing our sheet name.
+        with self.assertRaises(KeyError) as ex:
+            taas.compute_key_gid(
+                "MySource", {"key": "foo", "gid": 0, "url": "http://example.com/"}
+            )
+
+        self.assertRegexpMatches(ex.exception.message, "MySource")


### PR DESCRIPTION
The original config format required `key` and `gid` fields that had to be extracted from the GSS URL and provided separately.

- These changes allow a much more human friendly `url` to be supplied.
- Both `key` and `gid` are still supported, so PRs using them will land fine.
- Supplying both a key/gid *and* a URL will result in a friendly exception being raised.
- Includes test cases, and updates to the config file for the new format.

Based on top of PR #21, since I'm expecting that to merge imminently.