### PR TITLE
config.yml: Update ISO column names for countries.

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -56,11 +56,11 @@ sources:
                 id: ID
 
                 iso3:
-                    field: ISO 3166-3:2013 Alpha 3-Codes
+                    field: ISO 3166-1 Alpha 3-Codes
                     optional: True
 
                 iso2:
-                    field: ISO 3166-2:2013 Alpha 2-Codes
+                    field: ISO 3166-1 Alpha 2-Codes
                     optional: True
 
                 # Unofficial but generally used fields. These
@@ -68,13 +68,13 @@ sources:
                 x-alpha-2:
                     field:
                         - x Alpha2 codes
-                        - ISO 3166-2:2013 Alpha 2-Codes
+                        - ISO 3166-1 Alpha 2-Codes
                     optional: True
 
                 x-alpha-3:
                     field:
                         - x Alpha3 codes
-                        - ISO 3166-3:2013 Alpha 3-Codes
+                        - ISO 3166-1 Alpha 3-Codes
                     optional: True
 
                 # The old HRinfo ID, in case people want to match.
@@ -153,4 +153,3 @@ sources:
                 x-reliefweb-term-is:
                     field: "Match type - RW term is:"
                     optional: True
-


### PR DESCRIPTION
Our ISO codes are correctly "ISO 3166-1" codes, not -2 or -3 codes.
This is a common misunderstanding.

We've also removed the ISO year, since we'll always be publishing
the current standard.

In conjunction with @helenrc.