### PR TITLE
[TAAS-58] config.yml/countries: Add FTS Alt Term

### DIFF
--- a/taas/config.yml
+++ b/taas/config.yml
@@ -125,6 +125,11 @@ sources:
                         - m49 Alt Term
                         - Preferred Term
 
+                label.fts:
+                    field:
+                        - FTS Alt Term
+                        - Preferred Term
+
                 # Lat/Long are presented the same way as they
                 # are in HRinfo
 


### PR DESCRIPTION
Adds an FTS term to our list of alt terms. I've called this `fts` rather than `financialtrackingservice` or `financial_tracking_service` because the latter is *very* long to type, and as far as I know we're targetting UNOCHA and friends as users of our data, who are already familiar with the acronym FTS.