### PR TITLE
[TAAS-49] Split config into config.d

### DIFF
--- a/taas/__init__.py
+++ b/taas/__init__.py
@@ -16,7 +16,7 @@ from taas.mapping import make_map
 def debug(string):
     """Display a debug message."""
     # Simple now, but a function means we can turn them off, or redirect them later.
-    print string
+    print(string)
 
 
 def project_root():

--- a/taas/__init__.py
+++ b/taas/__init__.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import glob
 import os
 import re
 import sys
@@ -75,21 +76,56 @@ def json_root():
     return data_root("json")
 
 
-def read_config(file=None):
+def _merge_config(new, base):
+    """
+        Internal function that merges config sections into a base config.
+
+        Returns the new config data structure.
+    """
+
+    # Thanks, StackOverflow! http://stackoverflow.com/questions/823196/yaml-merge-in-python
+
+    # If we've got two dicts, merge them.
+    if isinstance(new, dict) and isinstance(base, dict):
+        for k, v in base.iteritems():
+            if k not in new:
+                new[k] = v
+            else:
+                new[k] = _merge_config(new[k], v)
+
+    # If we didn't merge our dicts, this still returns the item we want to add.
+    return new
+
+
+def read_config(path=None):
     """
     Reads the TAAS config and returns it as a data structure.
 
-    Read the default config file if none specified.
+    If given a directory, all files in the directory with a `.yml` extension will
+    be read and merged.
+
+    Read the default config directory if none specified.
 
     Throws on failure.
 
     """
 
-    if file is None:
-        file = os.path.join(project_root(), "config.yml")
+    if path is None:
+        path = os.path.join(project_root(), "config.d")
 
-    with open(file) as stream:
-        return yaml.load(stream)
+    if os.path.isfile(path):
+        with open(path) as stream:
+            return yaml.load(stream)
+
+    # If we're here, we have a directory. (Or we're about
+    # to throw an exception, because we don't.)
+    config = {}
+    for file in glob.glob(os.path.join(path, "*.yml")):
+        with open(file) as stream:
+            sub_config = yaml.load(stream)
+            config = _merge_config(sub_config, config)
+
+    return config
 
 
 def read_sheet_csv(name, directory=None):

--- a/taas/config.d/README.md
+++ b/taas/config.d/README.md
@@ -1,0 +1,3 @@
+This directory contains sources for our gss2json pipeline, in YAML format. They each act as if
+they were under the `sources` key in the top-level config, but by being in separate files they're
+much easier to work with, and we avoid lots of merge conflicts when adding or removing configuration.

--- a/taas/config.d/README.md
+++ b/taas/config.d/README.md
@@ -1,3 +1,5 @@
-This directory contains sources for our gss2json pipeline, in YAML format. They each act as if
-they were under the `sources` key in the top-level config, but by being in separate files they're
-much easier to work with, and we avoid lots of merge conflicts when adding or removing configuration.
+This directory contains sources for our gss2json pipeline, in YAML format. They still require
+the `sources` key, as they get merged together into one complete config.
+
+By being in separate files they're much easier to work with, and we avoid lots
+of merge conflicts when adding or removing configuration.

--- a/taas/config.d/countries.yml
+++ b/taas/config.d/countries.yml
@@ -1,54 +1,5 @@
 ---
-# TODO: We should have a config.d or similar setup; this means adding
-#       additional services doesn't result in them fighting for control of the
-#       same config file.
-
 sources:
-    # This maps directly to the API URL
-    functional_roles:
-        beta-v2:
-            url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
-
-            # Mapping of column names -> API fields
-            # Columns that aren't mentioned get ignored.
-            mapping:
-                "@context":
-                    type: literal
-                    value: https://raw.githubusercontent.com/UN-OCHA/taas-data/master/json/v1/functional_roles.jsonld
-                "@id":
-                    type: concat
-                    prefix: http://vocabulary.unocha.org/FunctionalRole/
-                    field: ID
-
-                    # XXX: This shouldn't be optional, but the current dataset
-                    #      is missing an ID in the sheet, so it is for now.
-                    optional: True
-
-                scope: Scope
-
-                # These all form a language map. See TAAS-16 for more details.
-                # https://humanitarian.atlassian.net/browse/TAAS-16
-                label.i-default: Preferred Term
-                label.en: Preferred Term
-
-                label.fr:
-                    field: French Term
-                    optional: True
-
-                label.es:
-                    field: Spanish Term
-                    optional: True
-
-    global_coordination_groups:
-        beta-v1:
-            url: https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0
-            mapping:
-                id: HRinfo ID
-                label: Preferred Term
-                acronym: ACRONYM
-                group_type: Group Type
-                homepage: Homepage
-
     countries:
         beta-v1:
             url: https://docs.google.com/spreadsheets/d/1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY/edit#gid=1528390745
@@ -139,25 +90,4 @@ sources:
 
                 geolocation.lon:
                     field: Longitude
-                    optional: True
-
-    organization_types:
-        beta-v1:
-            key: 12nKxos71U6lkttpyYTfwI2bDq9yeN1J7jplHocN96_0
-            gid: 0
-            mapping:
-                id: HR.info ID
-                scope: Scope
-
-                label.default: Preferred Term
-                label.reliefweb:
-                    field: RW Alt Term
-                    optional: True
-
-                reliefweb_id:
-                    field: RW API ID
-                    optional: True
-
-                x-reliefweb-term-is:
-                    field: "Match type - RW term is:"
                     optional: True

--- a/taas/config.d/functional_roles.yml
+++ b/taas/config.d/functional_roles.yml
@@ -15,10 +15,6 @@ sources:
                     prefix: http://vocabulary.unocha.org/FunctionalRole/
                     field: ID
 
-                    # XXX: This shouldn't be optional, but the current dataset
-                    #      is missing an ID in the sheet, so it is for now.
-                    optional: True
-
                 scope: Scope
 
                 # These all form a language map. See TAAS-16 for more details.

--- a/taas/config.d/functional_roles.yml
+++ b/taas/config.d/functional_roles.yml
@@ -1,0 +1,35 @@
+---
+sources:
+    functional_roles:
+        beta-v2:
+            url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
+
+            # Mapping of column names -> API fields
+            # Columns that aren't mentioned get ignored.
+            mapping:
+                "@context":
+                    type: literal
+                    value: https://raw.githubusercontent.com/UN-OCHA/taas-data/master/json/v1/functional_roles.jsonld
+                "@id":
+                    type: concat
+                    prefix: http://vocabulary.unocha.org/FunctionalRole/
+                    field: ID
+
+                    # XXX: This shouldn't be optional, but the current dataset
+                    #      is missing an ID in the sheet, so it is for now.
+                    optional: True
+
+                scope: Scope
+
+                # These all form a language map. See TAAS-16 for more details.
+                # https://humanitarian.atlassian.net/browse/TAAS-16
+                label.i-default: Preferred Term
+                label.en: Preferred Term
+
+                label.fr:
+                    field: French Term
+                    optional: True
+
+                label.es:
+                    field: Spanish Term
+                    optional: True

--- a/taas/config.d/global_coordination_groups.yml
+++ b/taas/config.d/global_coordination_groups.yml
@@ -1,0 +1,11 @@
+---
+sources:
+    global_coordination_groups:
+        beta-v1:
+            url: https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0
+            mapping:
+                id: HRinfo ID
+                label: Preferred Term
+                acronym: ACRONYM
+                group_type: Group Type
+                homepage: Homepage

--- a/taas/config.d/organization_types.yml
+++ b/taas/config.d/organization_types.yml
@@ -1,0 +1,22 @@
+---
+sources:
+    organization_types:
+        beta-v1:
+            key: 12nKxos71U6lkttpyYTfwI2bDq9yeN1J7jplHocN96_0
+            gid: 0
+            mapping:
+                id: HR.info ID
+                scope: Scope
+
+                label.default: Preferred Term
+                label.reliefweb:
+                    field: RW Alt Term
+                    optional: True
+
+                reliefweb_id:
+                    field: RW API ID
+                    optional: True
+
+                x-reliefweb-term-is:
+                    field: "Match type - RW term is:"
+                    optional: True

--- a/tests/config.d/durian.yml
+++ b/tests/config.d/durian.yml
@@ -1,0 +1,4 @@
+food:
+    durian:
+        type: fruit
+        taste: acquired

--- a/tests/config.d/vegemite.yml
+++ b/tests/config.d/vegemite.yml
@@ -1,0 +1,4 @@
+food:
+    vegemite:
+        type: breakfast spread
+        taste: acquired

--- a/tests/test_taas.py
+++ b/tests/test_taas.py
@@ -9,6 +9,7 @@ import unittest
 class TestTaas(unittest.TestCase):
     test_root = os.path.dirname(__file__)
     test_config = os.path.join(test_root, "config.yml")
+    test_config_d = os.path.join(test_root, "config.d")
 
     def test_process_csv(self):
         config = taas.read_config(self.test_config)
@@ -41,6 +42,14 @@ class TestTaas(unittest.TestCase):
 
         self.assertNotEqual(config['sources'], None)
         self.assertNotEqual(config['sources']['pokedex'], None)
+
+    def test_read_config_d(self):
+        config = taas.read_config(self.test_config_d)
+
+        print config
+
+        self.assertEqual(config['food']['vegemite']['type'], 'breakfast spread')
+        self.assertEqual(config['food']['durian']['type'], 'fruit')
 
     def test_taas_data_env(self):
         """


### PR DESCRIPTION
- Much easier maintenance of config.
- Manual test shows all existing vocabs are created with this change.
- Includes test cases.

This also includes some minor fixups, including a two-character change for python3 compatibility, and an adjustment to `functional_roles` to make the ID field mandatory. This helps assuage my QA bots' collective fears.