### PR TITLE
[BUGFIX] Linked fields can now be optional

### DIFF
--- a/taas/mapping.py
+++ b/taas/mapping.py
@@ -116,8 +116,13 @@ class Link(Concat):
         super().__init__(config)
 
     def emit(self, row):
-        # We'll start by getting the raw data.
+        # We'll start by getting the raw data. If this is a mandatory
+        # field which is empty, this will throw our exception for us.
         raw = Map.emit(self, row)
+
+        # If there's no data, but we're optional, return nothing.
+        if raw is None:
+            return None
 
         # Then we drop everything before a literal ' - '
         ident = raw.split(' - ', 1)[0]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -92,9 +92,33 @@ class TestMapping(unittest.TestCase):
             "prefix": "https://example.com/"
         })
 
+        # Make sure links work
         self.assertEqual(
             link.emit(self.row),
             "https://example.com/42"
+        )
+
+        # Make sure links throw if the link is missing
+        with self.assertRaises(ValueError):
+            link.emit({"link": ""})
+
+        # Here comes and optional link. It shouldn't throw.
+        optional_link = Link({
+            "field": "link",
+            "prefix": "https://example.com/",
+            "optional": True
+        })
+
+        # Make sure the optional link works the same as a strict link
+        self.assertEqual(
+            optional_link.emit(self.row),
+            "https://example.com/42"
+        )
+
+        # The optional link should return None for empty data.
+        self.assertEqual(
+            optional_link.emit({"link": ""}),
+            None
         )
 
     def test_make_map(self):


### PR DESCRIPTION
Our config allows sections like this:

```YAML
organization:
    type: link
    field: Organization
    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organizations/
```

This looks for a column named "Organization" with data in the form of
`457 - Médecins Sans Frontières`. The special `link` type strips off the
prefix (everything before the ` - `) and then processes it as a standard
`concat` field. In this case, we'd produce the link `https://www.humanitarianresponse.info/en/api/v1.0/organizations/457`.

However as coded these links *insisted* their fields were populated. Even
if they were marked as optional, they would throw an error if they had a blank
field.

This PR fixes support for the `optional` field for link fields, so we can now
have:

```YAML
organization:
    type: link
    field: Organization
    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organizations/
    optional: True
```

If the data is missing, we'll just return a value of `null` for that field.

Links were always supposed to work this way, but due to programmer error I
didn't previously test the situation where data was empty.

This PR both corrects the bug, and adds test cases to help prevent it
coming back.