### PR TITLE
[TAAS-59] Trim data of leading/trailing spaces.

### DIFF
--- a/taas/mapping.py
+++ b/taas/mapping.py
@@ -50,6 +50,7 @@ class Map(Mapping):
             self.field = config["field"]
 
         self.optional = config.get("optional", False)
+        self.trim = config.get("trim", True)
 
     def emit(self, row):
 
@@ -65,6 +66,8 @@ class Map(Mapping):
                 )
 
             if len(value) > 0:
+                if self.trim:
+                    return value.strip()
                 return value
 
         # The column was there, but the data was empty. If it's

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -34,6 +34,23 @@ class TestMapping(unittest.TestCase):
             "baz"
         )
 
+    def test_map_strip(self):
+        mymap = Map({"field": "foo"})
+
+        # Fields should trim spaces by default
+        self.assertEqual(
+            mymap.emit({"foo": " data "}),
+            "data"
+        )
+
+        # If we set trim to false, we should get back unchanged data
+        notrim_map = Map({"field": "foo", "trim": False})
+
+        self.assertEqual(
+            notrim_map.emit({"foo": " data "}),
+            " data "
+        )
+
     def test_map_optional(self):
         mymap = Map({"field": "foo", "optional": True})
 


### PR DESCRIPTION
It's very easy to end up with leading/trailing spaces in spreadsheet
data. This change strips them out by default, but this can be disabled
on a per-field basis by setting the `trim: False` in the relevant config
section.

Includes tests.