### PR TITLE
[TAAS-19][TAAS-65] Org exports and fancy link format

### DIFF
--- a/taas/config.d/organizations.yml
+++ b/taas/config.d/organizations.yml
@@ -2,8 +2,7 @@
 sources:
     organizations:
         beta-v1:
-            key: 1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ
-            gid: 518938746
+            url: https://docs.google.com/spreadsheets/d/1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ/edit#gid=518938746
             mapping:
                 id: HR info ID
                 label: Preferred Term

--- a/taas/config.d/organizations.yml
+++ b/taas/config.d/organizations.yml
@@ -1,0 +1,25 @@
+---
+sources:
+    organizations:
+        beta-v1:
+            key: 1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ
+            gid: 518938746
+            mapping:
+                id: HR info ID
+                label: Preferred Term
+                acronym:
+                    type: map
+                    field: ACRONYM
+                    optional: True
+                homepage:
+                    type: map
+                    field: homepage
+                    optional: True
+                type:
+                    type: link
+                    field: OrgTypeID - OrgTypePreferredTerm
+                    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organization_types/
+                fts_id:
+                    type: map
+                    field: FinancialTrackingService ID
+                    optional: True

--- a/taas/config.d/organizations.yml
+++ b/taas/config.d/organizations.yml
@@ -15,11 +15,18 @@ sources:
                     type: map
                     field: homepage
                     optional: True
-                type:
-                    type: link
-                    field: OrgTypeID - OrgTypePreferredTerm
-                    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organization_types/
                 fts_id:
                     type: map
                     field: FinancialTrackingService ID
                     optional: True
+
+                # This gives us a map with a machine-friendly URL,
+                # and a human-friendly ID.
+                type.id:
+                    type: link
+                    field: OrgTypeID - OrgTypePreferredTerm
+                    prefix: https://www.humanitarianresponse.info/en/api/v1.0/organization_types/
+                type.label:
+                    type: link
+                    field: OrgTypeID - OrgTypePreferredTerm
+                    from: label

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -8,7 +8,7 @@ class TestMapping(unittest.TestCase):
         "id": "3",
         "foo": "bar",
         "baz": "bazza",
-        "link": "42 - Some other endpoint"
+        "link": "42 - Golbat"
     }
 
     def test_literal(self):
@@ -137,6 +137,39 @@ class TestMapping(unittest.TestCase):
             optional_link.emit({"link": ""}),
             None
         )
+
+    def test_link_labels(self):
+
+        # Explicit from field.
+        link = Link({
+            "field": "link",
+            "prefix": "https://example.com/",
+            "from": "id"
+        })
+
+        self.assertEqual(
+            link.emit(self.row),
+            "https://example.com/42"
+        )
+
+        # Select label
+        link = Link({
+            "field": "link",
+            "from": "label"
+        })
+
+        self.assertEqual(
+            link.emit(self.row),
+            "Golbat"
+        )
+
+        # Test exceptions on bad `from` field.
+        with self.assertRaises(RuntimeError):
+            link = Link({
+                "field": "link",
+                "prefix": "https://example.com/",
+                "from": "this_is_aninvalid_from_field"
+            })
 
     def test_make_map(self):
         """


### PR DESCRIPTION
## Organizations

The config change gives us an `organizations.json` export, with records which look like this:

```JSON
{
    "acronym": "MSF", 
    "fts_id": null, 
    "homepage": "http://www.msf.org/", 
    "id": "457", 
    "label": "M\u00e9decins Sans Fronti\u00e8res", 
    "type": {
	"id": "https://www.humanitarianresponse.info/en/api/v1.0/organization_types/437", 
	"label": "International NGO"
    }
}
```

Organisations is *very* large (~4000 records), and the content is still somewhat in a state of flux, so we won't be putting a link to this up on the main vocabulary.unocha.org page, but we will be sharing it internally for feedback.

At some point our `id` links will change to referring to our own data rather than into HR.info, but that requires me to have written some record-fragment code, which I haven't done yet.

## Fancy Links

The changes to `mapping.py` add an extra field to our `link` class called `from`. This can be set to either `id` (the default), or `label`. 

Given a field like `25 - Pikachu`, using `from: id` will give us `25`, and `from: label` will give us `Pikachu`. This allows us to export links alongside human-friendly names, as we've done so with the `type` field in organizations above.

Internally (in `mapping.py`) we call the field `return_part`, because `from` is a reserved word in Python, and I've learnt not to mess with reserved words. (Suggestions for better names welcome.)

## Test Cases

<s>Oh drat, I didn't write a test-case. I bet Code Climate will fail me.</s>

Tests included. :)