### PR TITLE
[TAAS-19] Organizations not to be built by default.

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -29,6 +29,27 @@ The `url` field *must* contain a URL complete with the `gid=` parameter at the e
 
 A config file can contain multiple sources, and each source can contain multiple versions.
 
+## Options block
+
+Each source may have an optional `options` block, which changes how the source is processed.
+
+The only valid option at this time is the `build_by_default`, which defaults to `True`. This can be set to `False` to disable the export of this entire taxonomy. In this case the source can still be exported explicitly with `gss2json <source-name>`.
+
+The following example defines a `functional_roles` export, but not one that will be built by default.
+
+```YAML
+---
+sources:
+    functional_roles:
+        options:
+            build_by_default: False
+        beta-v1:
+            url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
+            mapping:
+                id: ID
+                label: Preferred Term
+```
+
 ## Output keys
 
 Output fields are generated exactly presented in the configuration file, with one exception. If the field contains a period (`.`) then it will be transformed into a JSON map. For example:

--- a/taas/__init__.py
+++ b/taas/__init__.py
@@ -346,13 +346,16 @@ def process_source(source_name, source):
     # TODO: We should have a service class definition, rather than trusting our
     #       config file is in the right format.
 
-    for version in source:
-        options = source[version]
+    for version, version_config in source.iteritems():
 
-        (key, gid) = compute_key_gid(source_name, options)
+        # Skip our options block
+        if version == 'options':
+            continue
+
+        (key, gid) = compute_key_gid(source_name, version_config)
 
         google_sheet_to_json(
-            source_name, version, key, gid, options['mapping']
+            source_name, version, key, gid, version_config['mapping']
         )
 
 
@@ -362,8 +365,14 @@ def process_sources(config, sources=None):
 
         Process all sources if none are provided.
     """
+
+    # If there are no sources, we build everything that doesn't have
+    # `build_by_default` set to False
     if sources is None:
-        sources = config['sources']
+        sources = []
+        for source, src_config in config['sources'].iteritems():
+            if src_config.get('options', {}).get('build_by_default', True):
+                sources.append(source)
 
     for source in sources:
         if source not in config['sources']:

--- a/taas/config.d/organizations.yml
+++ b/taas/config.d/organizations.yml
@@ -1,6 +1,8 @@
 ---
 sources:
     organizations:
+        options:
+            build_by_default: False
         beta-v1:
             url: https://docs.google.com/spreadsheets/d/1oa7Wknz64dMQlV2XsW0ssjh6Gw5SnHVfGxDSw_5eKOQ/edit#gid=518938746
             mapping:


### PR DESCRIPTION
The contents of the organizations sheet is still in a state of flux, so while
we have a solid config for reading it, we shouldn't be exporting it just yet.

This PR allows the config to be kept, but sets a flag indicating that it should
not be set by default.

Tested by hand:

- `gss2json` (builds everything but organizations)
- `gss2json organizations` (builds only organizations)