### PR TITLE
[DIAG] Better diagnostics when malformed links are encountered.

### DIFF
--- a/taas/mapping.py
+++ b/taas/mapping.py
@@ -136,8 +136,15 @@ class Link(Concat):
         if raw is None:
             return None
 
-        # Then split on a literal ' - '
-        ident, label = raw.split(' - ', 1)
+        ident, label = None, None
+
+        try:
+            # Then split on a literal ' - '
+            ident, label = raw.split(' - ', 1)
+        except ValueError:
+            raise ValueError("Link field {} cannot find link string ' - ' in value {}".format(
+                self.field, raw
+            ))
 
         # And pass up to our parent class, so it can concat and adjust
         # to taste.

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -119,6 +119,10 @@ class TestMapping(unittest.TestCase):
         with self.assertRaises(ValueError):
             link.emit({"link": ""})
 
+        # Ditto if it's malformed
+        with self.assertRaises(ValueError):
+            link.emit({"link": "A Missing Link"})
+
         # Here comes and optional link. It shouldn't throw.
         optional_link = Link({
             "field": "link",


### PR DESCRIPTION
We always expect links to have a ` - ` string in them. If they didn't,
we'd get a stack-trace, but not know what field was causing problems.

With this change, we get a message back similar to:

```
ValueError: Link field ['Country / Operation'] cannot find link string ' - ' in value Ethiopia
```

This allows us to which field was doing the processing, and the data it
was using at the time.

Includes tests.