### PR TITLE
[BUGFIX/FEATURE] Support any level of nested keys

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -13,3 +13,4 @@ sources:
                 name.en: English Name
                 name.jp: Japanese Name
                 type: Type
+                characteristic.weight.kg: Weight (kg)

--- a/tests/pokedex.csv
+++ b/tests/pokedex.csv
@@ -1,5 +1,5 @@
-Pokedex ID,English Name,Japanese Name,Type
-1,Bulbasaur,フシギソウ,grass
-2,Ivysaur,フシギギソウ,grass
-3,Venusaur,フシギバナ,grass
-4,Charmander,ヒトカゲ,fire
+Pokedex ID,English Name,Japanese Name,Type,Weight (kg)
+1,Bulbasaur,フシギソウ,grass,6.9
+2,Ivysaur,フシギギソウ,grass,13.0
+3,Venusaur,フシギバナ,grass,100.0
+4,Charmander,ヒトカゲ,fire,8.5

--- a/tests/test_taas.py
+++ b/tests/test_taas.py
@@ -27,6 +27,7 @@ class TestTaas(unittest.TestCase):
         self.assertEqual(bulbasaur['id'], '1')
         self.assertEqual(bulbasaur['name']['en'], 'Bulbasaur')
         self.assertEqual(bulbasaur['name']['jp'], 'フシギソウ')
+        self.assertEqual(bulbasaur['characteristic']['weight']['kg'], '6.9')
         self.assertEqual(bulbasaur['type'], 'grass')
 
     def clear_env(self):


### PR DESCRIPTION
Previously we could only handle one level of nested keys, so `label.en`
was fine, but `address.country.iso` was not.

This change lets us support any number of nested keys.

Includes tests.

Many thanks to @nickzoic for teaching me how to do fancy things with
dicts in python, even if I don't use that knowledge here. :)