### PR TITLE
[TAAS-66] JSON fragment support

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -10,6 +10,8 @@ Our configuration is in [YAML](http://yaml.org/) format, and consists of a seque
 
 Each source can contain a number of exports, which would usually be version (`v1`, `v2`, etc), allowing for us to use the same data to generate different outputs. These directly translate to filenames on output.
 
+### Version options
+
 Each version has a human-friendly spreadsheet `url` (which we use to generate our own URL for data extraction in CSV), and a `mapping`, which describes how we map spreadsheet columns into JSON structures.
 
 We'll cover the mapping in more detail momentarily, but it consists of JSON field names on the left, and Spreadsheet field names on the right. In the following config, we'd create a file named `beta-v1/function_roles.json` where each record has an `id` field and a `label` field, which came from the `ID` and `Preferred Term` columns in our spreadsheet.
@@ -20,12 +22,17 @@ sources:
     functional_roles:
         beta-v1:
             url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
+            fragment_key: id
             mapping:
                 id: ID
                 label: Preferred Term
 ```
 
 The `url` field *must* contain a URL complete with the `gid=` parameter at the end. For spreadsheets that consist of multiple sheets, the gid parameter specifies the individual sheet to be read. The `/edit` part of the URL is optional. In almost all cases a simple copy-and-paste will work correctly.
+
+A source *may* contain a `fragment_key`. If set, JSON fragments (individual files containing only a single record each) will be emitted in addition to the main file, using the contents of the mapping field specified. For example, if we're using numeric IDs, the example above would create files named `beta-v1/functional_roles/1`, `beta-v1/function_roles/2`, etc.
+
+To match how existing APIs present their records, fragments do not have the `.json` or any other extension.
 
 A config file can contain multiple sources, and each source can contain multiple versions.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appdirs>=1.4.2
+backports.tempfile==1.0rc1
 cffi==1.9.1
 click==6.7
 codeclimate-test-reporter==0.2.1

--- a/taas/config.d/countries.yml
+++ b/taas/config.d/countries.yml
@@ -3,6 +3,7 @@ sources:
     countries:
         beta-v1:
             url: https://docs.google.com/spreadsheets/d/1NjSI2LaS3SqbgYc0HdD8oIb7lofGtiHgoKKATCpwVdY/edit#gid=1528390745
+            fragment_key: id
             mapping:
                 id: ID
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -8,6 +8,7 @@ sources:
         v1:
             key: None
             gid: 0
+            fragment_key: id
             mapping:
                 id: Pokedex ID
                 name.en: English Name

--- a/tests/test_taas.py
+++ b/tests/test_taas.py
@@ -1,8 +1,10 @@
 # vim: set fileencoding=utf-8
 
+import json
 import os
 import sys
 import taas
+from backports import tempfile
 import unittest
 
 
@@ -102,3 +104,62 @@ class TestTaas(unittest.TestCase):
             )
 
         self.assertRegexpMatches(ex.exception.message, "MySource")
+
+    def test_fragments(self):
+        config = taas.read_config(self.test_config)
+
+        source = 'pokedex'
+        version = 'v1'
+        version_config = config['sources'][source][version]
+
+        data = taas.process_csv(
+            source,
+            version_config['mapping'],
+            self.test_root
+        )
+
+        # TempDirs will clean themselves up after running. <3
+        with tempfile.TemporaryDirectory() as tempdir:
+
+            # 'tmpdir/v1'
+            version_dir = os.path.join(tempdir, version)
+
+            # 'tmpdir/v1/pokedex'
+            fragment_dir = os.path.join(version_dir, source)
+
+            # 'tmpdir/v1/pokedex.json'
+            full_json = fragment_dir + ".json"
+
+            # Sanity check: None of our paths exist already
+            assert(not os.path.isdir(version_dir))
+
+            # Now process our data
+            taas.save_json(source, version, data, tempdir, version_config)
+
+            # And let's read it back in!
+
+            # Test the written data to see if it contains things we expect.
+            with open(full_json, 'r') as json_in:
+                read_data = json.load(json_in)
+
+                # Bulbasar should be our zeroth record.
+                bulbasaur = read_data['data'][0]
+
+                self.assertEqual(bulbasaur['id'], '1')
+                self.assertEqual(bulbasaur['name']['en'], 'Bulbasaur')
+                self.assertEqual(bulbasaur['name']['jp'], u'フシギソウ')
+                self.assertEqual(bulbasaur['characteristic']['weight']['kg'], '6.9')
+                self.assertEqual(bulbasaur['type'], 'grass')
+
+            # And let's test a fragment
+            charmander_id = '4'
+
+            with open(os.path.join(fragment_dir, charmander_id)) as json_in:
+                read_data = json.load(json_in)
+
+                # Our *only* record should now be Charmander
+
+                charmander = read_data['data'][0]
+
+                self.assertEqual(charmander['id'], charmander_id)
+                self.assertEqual(charmander['name']['en'], "Charmander")


### PR DESCRIPTION
This PR adds the ability to emit JSON fragments in addition to our regular output. These files contain only a single record each and means we can have data that links to *individual* records, which is important for large data sets, and for interconnected data.

Includes tests.