### PR TITLE
[TAAS-69] Functional roles to beta-v1, cleanup links

### DIFF
--- a/taas/config.d/functional_roles.yml
+++ b/taas/config.d/functional_roles.yml
@@ -1,18 +1,26 @@
 ---
 sources:
     functional_roles:
-        beta-v2:
+        beta-v1:
             url: https://docs.google.com/spreadsheets/d/1c9wehuauQAAegElIRI6vhWktKSI-PcPjHHiXdqASonk/edit#gid=0
+            fragment_key: id
 
             # Mapping of column names -> API fields
             # Columns that aren't mentioned get ignored.
             mapping:
+
+                # Our numeric ID
+                id: ID
+
+                # Our rich JSON-LD data. Ideally context would be a top-level field, as opposed
+                # to being attached to each element.
+
                 "@context":
                     type: literal
-                    value: https://raw.githubusercontent.com/UN-OCHA/taas-data/master/json/v1/functional_roles.jsonld
+                    value: http://vocabulary.unocha.org/json/beta-v1/functional_roles.jsonld
                 "@id":
                     type: concat
-                    prefix: http://vocabulary.unocha.org/FunctionalRole/
+                    prefix: http://vocabulary.unocha.org/json/beta-v1/functional_roles/
                     field: ID
 
                 scope: Scope


### PR DESCRIPTION
This change:

- Changes the version back to `beta-v1`, since nobody was actually using
  the old version and we're safe to change it.
- Emits JSON fragments for each role.
- Updates the `@id` field to link to those fragments.
- Updates the context to use our preferred URL.
- Laments the fact that we can't provide structure-wide context yet.

Tested locally.