### PR TITLE
Create new beta-v2 output for the global coordination groups, with French labels

### DIFF
--- a/taas/config.d/global_coordination_groups.yml
+++ b/taas/config.d/global_coordination_groups.yml
@@ -9,3 +9,13 @@ sources:
                 acronym: ACRONYM
                 group_type: Group Type
                 homepage: Homepage
+        beta-v2:
+            url: https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0
+            mapping:
+                id: HRinfo ID
+                label.default: Preferred Term
+                label.english: Preferred Term
+                label.french: Preferred Term (fr)
+                acronym: ACRONYM
+                group_type: Group Type
+                homepage: Homepage

--- a/taas/config.d/global_coordination_groups.yml
+++ b/taas/config.d/global_coordination_groups.yml
@@ -13,9 +13,12 @@ sources:
             url: https://docs.google.com/spreadsheets/d/1SxSircxhXMZCe0PWafCht-whjBdI9UqoeFeSUbiLGc4/edit#gid=0
             mapping:
                 id: HRinfo ID
-                label.default: Preferred Term
-                label.english: Preferred Term
-                label.french: Preferred Term (fr)
+                label.i-default: Preferred Term
+                label.en: Preferred Term
+                label.fr:
+                        type: map
+                        field: Preferred Term (fr)
+                        optional: True
                 acronym: ACRONYM
                 group_type: Group Type
                 homepage: Homepage


### PR DESCRIPTION
Added a new beta-v2 section to the config for global coordination groups. This uses the multilingual structure that @emmajane suggested, while still leaving the old beta-v1 JSON in place to avoid breaking existing systems.

The beta-v2 JSON output looks like this:

```
        {
            "acronym": "SHL", 
            "group_type": "Cluster", 
            "homepage": "https://www.sheltercluster.org/", 
            "id": "4", 
            "label": {
                "default": "Emergency Shelter and NFI", 
                "english": "Emergency Shelter and NFI", 
                "french": "Abris d'urgence et NFI"
            }
        }, 
```