### PR TITLE
[TAAS-82] add ocha services config

### DIFF
--- a/taas/config.d/functional_roles.yml
+++ b/taas/config.d/functional_roles.yml
@@ -17,10 +17,10 @@ sources:
 
                 "@context":
                     type: literal
-                    value: http://vocabulary.unocha.org/json/beta-v1/functional_roles.jsonld
+                    value: https://vocabulary.unocha.org/json/beta-v1/functional_roles.jsonld
                 "@id":
                     type: concat
-                    prefix: http://vocabulary.unocha.org/json/beta-v1/functional_roles/
+                    prefix: https://vocabulary.unocha.org/json/beta-v1/functional_roles/
                     field: ID
 
                 scope: Scope

--- a/taas/config.d/ocha_services.yml
+++ b/taas/config.d/ocha_services.yml
@@ -1,0 +1,15 @@
+---
+sources:
+    ocha_services:
+        options:
+            build_by_default: True
+        beta-v1:
+            url: https://docs.google.com/spreadsheets/d/13SHu0DCZhXec6UskKDUUSCc35JPcRk5L9iJT2WuQRfk/edit#gid=1170456449
+            # Mapping of column names -> API fields
+            mapping:
+                id: ID
+                label: Name
+                url: URL
+                acronym:
+                    field: Acronym
+                    optional: True


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/TAAS-82

Adds config for associated GSS with minimal details of OCHA services.

(Also noticed that tests were updating the current 'https' functional role links with 'http' versions, so included that change too. Happy to split that into another ticket/ remove it.) 