### PR TITLE
[OPS-7389] allow later versions of test packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 
 python:
-  - 3.6
+  - 3.8
 
 install:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 
 python:
-  - 3.8
+  - 3.6
 
 install:
   - make

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ GIT=git
 SED=sed
 
 venv: requirements.txt
-	virtualenv --python=python3.8 --system-site-packages venv
+  # 3.6 appears to be required to pass the travis tests.
+  # 3.8 is the version used in the base docker image.
+	virtualenv --python=python3.6 --system-site-packages venv
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install --upgrade appdirs
 	venv/bin/pip install --upgrade --editable .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GIT=git
 SED=sed
 
 venv: requirements.txt
-	virtualenv --python=python3.6 --system-site-packages venv
+	virtualenv --python=python3.8 --system-site-packages venv
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install --upgrade appdirs
 	venv/bin/pip install --upgrade --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 appdirs>=1.4.2
 backports.tempfile==1.0rc1
 cffi==1.12.3
-click==6.7
+click>=6.7
 coverage==4.5.3
 cryptography==2.3.1
 enum34==1.1.6
@@ -12,7 +12,7 @@ ipaddress==1.0.18
 itsdangerous==0.24
 Jinja2>=2.10.1
 MarkupSafe==0.23
-nose==1.3.7
+nose>=1.3.7
 packaging==16.8
 pep8==1.7.0
 py==1.4.32
@@ -20,11 +20,12 @@ pyasn1==0.2.3
 pycparser==2.17
 pyOpenSSL>=17.5.0
 pyparsing==2.2.0
-pytest==3.0.6
-pytest-cov==2.4.0
-python-coveralls==2.9.0
+pytest>=3.0.6
+pytest-cov>=2.4.0
+python-coveralls>=2.9.0
 PyYAML<5.0,>=4.2b1
 requests>=2.20.0
 six==1.10.0
+testresources>=2.0.1
 Werkzeug==0.15.4
 yamllint==1.6.1


### PR DESCRIPTION
Another crack at https://github.com/UN-OCHA/taas/pull/61

I also changed the python version number in the Makefile to match the current latest base image `FROM unocha/alpine-base-s6-python3:3.8`