### PR TITLE
[OPS-7389] try python version 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 
 python:
-  - 3.6
+  - 3.8
 
 install:
   - make

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SED=sed
 venv: requirements.txt
   # 3.6 appears to be required to pass the travis tests.
   # 3.8 is the version used in the base docker image.
-	virtualenv --python=python3.6 --system-site-packages venv
+	virtualenv --python=python3.8 --system-site-packages venv
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install --upgrade appdirs
 	venv/bin/pip install --upgrade --editable .


### PR DESCRIPTION
As suggested in https://github.com/UN-OCHA/taas/pull/62 - here's a PR changing just the python version (in the Makefile and in .travis.yml. 

Let's see what the tests say... (expecting them to fail, as they did on the other PR - but not sure where that got version 3.6.7 from...)